### PR TITLE
Change lualine normal mode color

### DIFF
--- a/lua/lualine/themes/calvera-nvim.lua
+++ b/lua/lualine/themes/calvera-nvim.lua
@@ -3,7 +3,7 @@ local colors = require('calvera.colors')
 local calvera = {}
 
 calvera.normal = {
-    a = {fg = colors.bg, bg = colors.accent, gui = 'bold'},
+    a = {fg = colors.bg, bg = colors.blue, gui = 'bold'},
     b = {fg = colors.title, bg = colors.active},
     c = {fg = colors.fg, bg = colors.selection}
 }


### PR DESCRIPTION
Before
![Screenshot from 2021-07-08 09-39-16](https://user-images.githubusercontent.com/43147494/124861541-6b857780-dfd1-11eb-941c-f3cf394dd9e7.png)

After
![Screenshot from 2021-07-08 09-40-42](https://user-images.githubusercontent.com/43147494/124861558-74764900-dfd1-11eb-9ff2-15649acd39dd.png)

Thanks for the great theme! :)
I feel changing section 'a' colour for normal mode lualine looks better this way. Any thoughts?