### PR TITLE
Remove reference to style variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ require('lualine').setup {
 
 ```lua
 -- Example config in lua
-vim.g.calvera_style = 'deep ocean'
 vim.g.calvera_italic_comments = true
 vim.g.calvera_italic_keywords = true
 vim.g.calvera_italic_functions = true


### PR DESCRIPTION
Seems that ability to change styles has been removed bb95a7948682212b9a05b45cb730149eae82838d which makes removed part of documentation a leftover.